### PR TITLE
fix `groups` in ProtoEnvironment

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,6 @@ jobs:
       matrix:
         version:
           - '1.10'
-          - '1.6'
           - 'pre'
         os:
           - ubuntu-latest

--- a/src/types/environments.jl
+++ b/src/types/environments.jl
@@ -25,7 +25,7 @@ struct ProtoEnvironment <: AbstractEnvironment
 	distances::Matrix{Float64}
 	angles::Matrix{Float64}
 	groups::Vector{Int64}
-	function ProtoEnvironment(df_rows, df_cols)
+	function ProtoEnvironment(df_rows, df_cols; groupcol=:bin_id)
 		distances = map(df_rows.latlon) do group
             haversine.(df_cols.latlon, Ref(group),) ./ 1000
         end |> x -> transpose(reduce(hcat, x))
@@ -33,7 +33,7 @@ struct ProtoEnvironment <: AbstractEnvironment
             deg2rad.(polarangle.(df_cols.latlon, Ref(group),))
         end |> x -> transpose(reduce(hcat, x))
 		# Use cols because that's always islands
-		groups = tiedindex(df_cols[:, "Island Group"])
+		groups = tiedindex(df_cols[:, groupcol])
 		return new(distances, angles, groups)
 	end
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,8 +1,11 @@
 [deps]
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
 Chain = "8be319e6-bccf-4806-a6f7-6fae938471bc"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Sextans = "c5b77123-0644-49ad-8775-a80d028b173c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,41 +7,62 @@ using Base: -, +
 using CSV
 using DataFrames
 using Chain
-
+using CategoricalArrays
 
 df_islands = @chain begin
-	joinpath(@__DIR__, "data", "environment.csv")
-	CSV.read(_, DataFrame)
-    subset(_, :Basin => ByRow(x -> occursin(r"pacific", lowercase(x))))
-    transform(_, [:Latitude, :Longitude] => ByRow((x,y) -> (x, y)) => :latlon)
+    joinpath(@__DIR__, "data", "environment.csv")
+    CSV.read(_, DataFrame)
+    subset(_, :Basin => ByRow(x -> occursin(r"india", lowercase(x))))
+    transform(_, [:Latitude, :Longitude] => ByRow((x, y) -> (x, y)) => :latlon)
 end
 
+lat_edge = Base.range(extrema(df_islands.Latitude)...; step=1)
+lon_edge = Base.range(extrema(df_islands.Longitude)...; step=1)
+
+df_islands.bin_lat = cut(df_islands.Latitude, lat_edge; extend=true)
+df_islands.bin_lon = cut(df_islands.Longitude, lon_edge; extend=true)
+
 df_groups = @chain df_islands begin
-	transform(_, :Longitude => ByRow(x -> x < 0 ? x + 360 : x) => identity)
-	subset(_, :Basin => ByRow(x -> occursin(r"pacific", lowercase(x))))
-	groupby(_, "Island Group")
-	combine(_, Cols(r"itude") .=> mean => identity)
-	transform(_, :Longitude => ByRow(x -> x > 180 ? x - 360 : x) => identity)
-	transform(_, "Island Group" => ByRow(x -> occursin(r"START", x) ? true : false) => :invalid_target)
-	transform(_, [:Latitude, :Longitude] => ByRow((x,y) -> (x, y)) => :latlon)
+    transform(_, :Longitude => ByRow(x -> x < 0 ? x + 360 : x) => identity)
+    subset(_, :Basin => ByRow(x -> occursin(r"india", lowercase(x))))
+    groupby(_, r"bin")
+    transform(_, Cols(r"itude") .=> mean => identity)
+    transform(_, :Longitude => ByRow(x -> x > 180 ? x - 360 : x) => identity)
+    transform(_, "Island Group" => ByRow(x -> occursin(r"START", x)) => :invalid_target)
+    transform(_, [:Latitude, :Longitude] => ByRow((x, y) -> (x, y)) => :latlon)
+    unique(_, :latlon)
+    insertcols(_, :bin_id => eachindex(_[:, "Island Group"]))
+    select(_, :latlon, r"bin", :invalid_target)
+end
+
+tmp = []
+
+for (i, row_out) in enumerate(eachrow(df_groups))
+    x = row_out.bin_lat .== df_islands.bin_lat .&& row_out.bin_lon .== df_islands.bin_lon
+    push!(tmp, (i, x))
+end
+
+df_islands.bin_id = fill(0, nrow(df_islands))
+for (id, idx) in tmp
+    df_islands.bin_id[idx] .= id
 end
 
 axm = Axioms(
-	max_iter = 50,
-	min_iter = 10,
-	default_precision=120,
-	max_range = 5000,
-	local_threshold = 5
+    max_iter=50,
+    min_iter=10,
+    default_precision=120,
+    max_range=5000,
+    local_threshold=5
 )
 
-agent = ActiveAgent(4500, 60, 4, missing)
+agent = ActiveAgent(1500, 60, 4, missing)
 
-targets = collect(3:nrow(df_groups))
+targets = collect(2:nrow(df_groups))
 
 proto_group = ProtoEnvironment(df_groups, df_islands)
 proto_island = ProtoEnvironment(df_islands, df_islands)
 
-migs = [TargetedMigration(proto_group, proto_island, start, target, axm) for start in [1, 2], target in targets]
+migs = [TargetedMigration(proto_group, proto_island, 1, target, axm) for target in targets]
 
 #=
 @testset "Sigmoid" begin
@@ -62,5 +83,5 @@ end
 =#
 
 @testset "Migrations" begin
-	include("types/migrations.jl")
+    include("types/migrations.jl")
 end

--- a/test/types/migrations.jl
+++ b/test/types/migrations.jl
@@ -15,5 +15,5 @@ end
 end
 
 @testset "Migrate" begin
-    @test [migrate!(mig, agent) for mig in migs] isa AbstractMatrix{<:AbstractMigration}
+    @test [migrate!(mig, agent) for mig in migs] isa AbstractArray{<:AbstractMigration}
 end


### PR DESCRIPTION
`groups` was previously created based upon “Island Group” by default. This should instead be `:bin_id` now, but may also be user-specified when calling `ProtoEnvironment()`.